### PR TITLE
Make NoCrossover's values configurable

### DIFF
--- a/pymoo/operators/crossover/nox.py
+++ b/pymoo/operators/crossover/nox.py
@@ -3,9 +3,8 @@ from pymoo.core.population import Population
 
 
 class NoCrossover(Crossover):
-
-    def __init__(self):
-        super().__init__(1, 1, 0.0)
+    def __init__(self, *, n_parents=1, n_offsprings=1, prob=0.0, **kwargs):
+        super().__init__(n_parents, n_offsprings, prob, **kwargs)
 
     def do(self, problem, pop, *args, random_state, **kwargs):
         return Population.create(*[random_state.choice(parents) for parents in pop])


### PR DESCRIPTION
Recreated from original PR: https://github.com/anyoptimization/pymoo/pull/742

Resolve #740 

The `NoCrossover` class hardcodes both `n_parents` and `n_offsprings` to 1. This makes it incompatible for `MixedVariableMating` which expects a crossover with `n_parents` and `n_offsprings` to be 2.

This PR allows instances of `NoCrossover` to be customized with arbitrary `n_parents` and `n_offspring` values.

```python
crossover = NoCrossover(n_parents=2, n_offsprings=2)
```

The values default to 1, which maintains compatibility with the current use of `NoCrossover`.